### PR TITLE
Node 0.6.x compatibility, fix require paths.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,33 @@
 {
-    "name": "watchn"
-  , "version": "0.1.1"
-  , "description": "Intelligently auto execute tasks on file/directory changes"
-  , "keywords": ["development tool", "watch", "notify", "dev", "development", "reporter", "test"]
-  , "author": "Matthew Kitt <mk.kitt@gmail.com> (http://mkitt.net/)"
-  , "homepage": "http://github.com/mkitt/watchn"
-  , "preferGlobal": true
-  , "repository": { "type" : "git", "url" : "http://github.com/mkitt/watchn.git" }
-  , "dependencies": {}
-  , "bin": { "watchn": "./bin/watchn" }
-  , "main": "index"
-  , "engines": { "node": "0.4.x" }
+  "name": "watchn",
+  "version": "0.1.1",
+  "description": "Intelligently auto execute tasks on file/directory changes",
+  "keywords": [
+    "development tool",
+    "watch",
+    "notify",
+    "dev",
+    "development",
+    "reporter",
+    "test"
+  ],
+  "author": "Matthew Kitt <mk.kitt@gmail.com> (http://mkitt.net/)",
+  "homepage": "http://github.com/mkitt/watchn",
+  "preferGlobal": true,
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mkitt/watchn.git"
+  },
+  "dependencies": {},
+  "bin": {
+    "watchn": "./bin/watchn"
+  },
+  "main": "index",
+  "engines": {
+    "node": "0.6.x"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "make"
+  }
 }
-

--- a/test/map.test.js
+++ b/test/map.test.js
@@ -1,5 +1,5 @@
 
-var Map = require('map')
+var Map = require('../lib/map')
 var assert = require('assert')
 var map
 

--- a/test/reporters/coffee_reporter.test.js
+++ b/test/reporters/coffee_reporter.test.js
@@ -1,6 +1,6 @@
 
 var assert = require('assert')
-var CoffeeReporter = require('reporters/coffee_reporter')
+var CoffeeReporter = require('../../lib/reporters/coffee_reporter')
 var reporter
 
 function before() {

--- a/test/reporters/docco_reporter.test.js
+++ b/test/reporters/docco_reporter.test.js
@@ -1,6 +1,6 @@
 
 var assert = require('assert')
-var DoccoReporter = require('reporters/docco_reporter')
+var DoccoReporter = require('../../lib/reporters/docco_reporter')
 var reporter
 
 function before() {

--- a/test/reporters/expresso_reporter.test.js
+++ b/test/reporters/expresso_reporter.test.js
@@ -1,6 +1,6 @@
 
 var assert = require('assert')
-var ExpressoReporter = require('reporters/expresso_reporter')
+var ExpressoReporter = require('../../lib/reporters/expresso_reporter')
 var reporter
 
 function before() {

--- a/test/reporters/haml_reporter.test.js
+++ b/test/reporters/haml_reporter.test.js
@@ -1,6 +1,6 @@
 
 var assert = require('assert')
-var HamlReporter = require('reporters/haml_reporter')
+var HamlReporter = require('../../lib/reporters/haml_reporter')
 var reporter
 
 function before() {

--- a/test/reporters/jade_reporter.test.js
+++ b/test/reporters/jade_reporter.test.js
@@ -1,6 +1,6 @@
 
 var assert = require('assert')
-var JadeReporter = require('reporters/jade_reporter')
+var JadeReporter = require('../../lib/reporters/jade_reporter')
 var reporter
 
 function before() {

--- a/test/reporters/jasmine_dom_reporter.test.js
+++ b/test/reporters/jasmine_dom_reporter.test.js
@@ -1,6 +1,6 @@
 
 var assert = require('assert')
-var JasmineDomReporter = require('reporters/jasmine_dom_reporter')
+var JasmineDomReporter = require('../../lib/reporters/jasmine_dom_reporter')
 var reporter
 
 function before() {

--- a/test/reporters/jasmine_reporter.test.js
+++ b/test/reporters/jasmine_reporter.test.js
@@ -1,6 +1,6 @@
 
 var assert = require('assert')
-var JasmineReporter = require('reporters/jasmine_reporter')
+var JasmineReporter = require('../../lib/reporters/jasmine_reporter')
 var reporter
 
 function before() {

--- a/test/reporters/jshint_reporter.test.js
+++ b/test/reporters/jshint_reporter.test.js
@@ -1,6 +1,6 @@
 
 var assert = require('assert')
-var JSHintReporter = require('reporters/jshint_reporter')
+var JSHintReporter = require('../../lib/reporters/jshint_reporter')
 var reporter
 
 function before() {

--- a/test/reporters/reporter.test.js
+++ b/test/reporters/reporter.test.js
@@ -1,6 +1,6 @@
 
 var assert = require('assert')
-var Reporter = require('reporters/reporter')
+var Reporter = require('../../lib/reporters/reporter')
 var reporter
 
 function before() {

--- a/test/reporters/sass_reporter.test.js
+++ b/test/reporters/sass_reporter.test.js
@@ -1,6 +1,6 @@
 
 var assert = require('assert')
-var SASSReporter = require('reporters/sass_reporter')
+var SASSReporter = require('../../lib/reporters/sass_reporter')
 var reporter
 
 function before() {

--- a/test/reporters/scss_reporter.test.js
+++ b/test/reporters/scss_reporter.test.js
@@ -1,6 +1,6 @@
 
 var assert = require('assert')
-var SCSSReporter = require('reporters/scss_reporter')
+var SCSSReporter = require('../../lib/reporters/scss_reporter')
 var reporter
 
 function before() {

--- a/test/reporters/stylus_reporter.test.js
+++ b/test/reporters/stylus_reporter.test.js
@@ -1,6 +1,6 @@
 
 var assert = require('assert')
-var StylusReporter = require('reporters/stylus_reporter')
+var StylusReporter = require('../../lib/reporters/stylus_reporter')
 var reporter
 
 function before() {

--- a/test/reporters/uglify_reporter.test.js
+++ b/test/reporters/uglify_reporter.test.js
@@ -1,6 +1,6 @@
 
 var assert = require('assert')
-var UglifyReporter = require('reporters/uglify_reporter')
+var UglifyReporter = require('../../lib/reporters/uglify_reporter')
 var reporter
 
 function before() {

--- a/test/reporters/vows_reporter.test.js
+++ b/test/reporters/vows_reporter.test.js
@@ -1,6 +1,6 @@
 
 var assert = require('assert')
-var VowsReporter = require('reporters/vows_reporter')
+var VowsReporter = require('../../lib/reporters/vows_reporter')
 var reporter
 
 function before() {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,5 +1,5 @@
 
-var utils = require('utils')
+var utils = require('../lib/utils')
 var assert = require('assert')
 var path = require('path')
 var fixtures = path.normalize('./test/fixtures/')

--- a/test/watchn.test.js
+++ b/test/watchn.test.js
@@ -3,8 +3,8 @@ var fs = require('fs')
 var assert = require('assert')
 var path = require('path')
 var exec = require('child_process').exec
-var utils = require('utils')
-var Watchn = require('watchn')
+var utils = require('../lib/utils')
+var Watchn = require('../lib/watchn')
 var watchn
 var fixtures = path.normalize('./test/fixtures/')
 


### PR DESCRIPTION
Trying to use this with a node 0.6.x project will bork. Updated the package.json using `npm init`; this reformatted the commas, which I would suggest keeping since that's the output of the npm tool itself.

I also set the paths in the module so they are relative (it's a big no-no to modify require paths)

You may actually want to manually test that the module works, I just made it installable and the tests apparently 100% passing.
